### PR TITLE
Refactor token creation logic

### DIFF
--- a/contracts/Fin4Main.sol
+++ b/contracts/Fin4Main.sol
@@ -24,7 +24,7 @@ contract Fin4Main {
       Fin4MainCreator = msg.sender;
   }
 
-  address public Fin4TokenCreatorAddress;
+  address public Fin4UncappedTokenCreatorAddress;
   address public Fin4CappedTokenCreatorAddress;
   address public Fin4TokenManagementAddress;
   address public Fin4ClaimingAddress;
@@ -34,11 +34,11 @@ contract Fin4Main {
   address public Fin4GroupsAddress;
   address public Fin4SystemParametersAddress;
 
-  function setSatelliteAddresses(address tokenCreator, address cappedTokenCreator, address tokenManagement, address claiming,
+  function setSatelliteAddresses(address uncappedTokenCreator, address cappedTokenCreator, address tokenManagement, address claiming,
   address collections, address messaging, address proving, address groups, address systemParameters) public {
     // TODO use TCR instead of giving this right only to the creator of Fin4Main? #ConceptualDecision
     require (msg.sender == Fin4MainCreator, "Only the creator of Fin4Main can set satellite addresses");
-    Fin4TokenCreatorAddress = tokenCreator;
+    Fin4UncappedTokenCreatorAddress = uncappedTokenCreator;
     Fin4CappedTokenCreatorAddress = cappedTokenCreator;
     Fin4TokenManagementAddress = tokenManagement;
     Fin4ClaimingAddress = claiming;
@@ -50,8 +50,8 @@ contract Fin4Main {
   }
 
   function getSatelliteAddresses() public view returns(address, address, address, address, address, address, address, address, address) {
-    return (Fin4TokenCreatorAddress, Fin4CappedTokenCreatorAddress, Fin4TokenManagementAddress, Fin4ClaimingAddress, Fin4CollectionsAddress,
-      Fin4MessagingAddress, Fin4ProvingAddress, Fin4GroupsAddress, Fin4SystemParametersAddress);
+    return (Fin4UncappedTokenCreatorAddress, Fin4CappedTokenCreatorAddress, Fin4TokenManagementAddress, Fin4ClaimingAddress,
+      Fin4CollectionsAddress, Fin4MessagingAddress, Fin4ProvingAddress, Fin4GroupsAddress, Fin4SystemParametersAddress);
   }
 
   address public REPToken;

--- a/contracts/Fin4Main.sol
+++ b/contracts/Fin4Main.sol
@@ -24,6 +24,8 @@ contract Fin4Main {
       Fin4MainCreator = msg.sender;
   }
 
+  address public Fin4TokenCreatorAddress;
+  address public Fin4CappedTokenCreatorAddress;
   address public Fin4TokenManagementAddress;
   address public Fin4ClaimingAddress;
   address public Fin4CollectionsAddress;
@@ -32,10 +34,12 @@ contract Fin4Main {
   address public Fin4GroupsAddress;
   address public Fin4SystemParametersAddress;
 
-  function setSatelliteAddresses(address tokenManagement, address claiming, address collections,
-    address messaging, address proving, address groups, address systemParameters) public {
+  function setSatelliteAddresses(address tokenCreator, address cappedTokenCreator, address tokenManagement, address claiming,
+  address collections, address messaging, address proving, address groups, address systemParameters) public {
     // TODO use TCR instead of giving this right only to the creator of Fin4Main? #ConceptualDecision
     require (msg.sender == Fin4MainCreator, "Only the creator of Fin4Main can set satellite addresses");
+    Fin4TokenCreatorAddress = tokenCreator;
+    Fin4CappedTokenCreatorAddress = cappedTokenCreator;
     Fin4TokenManagementAddress = tokenManagement;
     Fin4ClaimingAddress = claiming;
     Fin4CollectionsAddress = collections;
@@ -45,9 +49,9 @@ contract Fin4Main {
     Fin4SystemParametersAddress = systemParameters;
   }
 
-  function getSatelliteAddresses() public view returns(address, address, address, address, address, address, address) {
-    return (Fin4TokenManagementAddress, Fin4ClaimingAddress, Fin4CollectionsAddress, Fin4MessagingAddress,
-      Fin4ProvingAddress, Fin4GroupsAddress, Fin4SystemParametersAddress);
+  function getSatelliteAddresses() public view returns(address, address, address, address, address, address, address, address, address) {
+    return (Fin4TokenCreatorAddress, Fin4CappedTokenCreatorAddress, Fin4TokenManagementAddress, Fin4ClaimingAddress, Fin4CollectionsAddress,
+      Fin4MessagingAddress, Fin4ProvingAddress, Fin4GroupsAddress, Fin4SystemParametersAddress);
   }
 
   address public REPToken;

--- a/contracts/Fin4Token.sol
+++ b/contracts/Fin4Token.sol
@@ -49,13 +49,39 @@ contract Fin4Token is Fin4TokenBase, ERC20Plus {
 
 contract Fin4TokenCapped is Fin4TokenBase, ERC20PlusCapped {
 
-  constructor(string memory name, string memory symbol, address tokenCreator, bool[] memory properties, uint[] memory values)
-    ERC20PlusCapped(name, symbol, uint8(values[1]), tokenCreator, properties[2], values[0], properties[0], properties[1], values[2])
+  constructor(string memory name, string memory symbol, address _tokenCreator, bool isBurnable,
+    bool isTransferable, bool isMintable, uint8 decimals, uint _initialSupply, uint cap)
+    ERC20PlusCapped(name, symbol, decimals, _tokenCreator, isBurnable, cap, isTransferable, isMintable, _initialSupply)
     Fin4TokenBase()
     public {
+      tokenCreator = _tokenCreator;
+      initialSupply = _initialSupply;
       _removeMinter(tokenCreator);
     }
 
-  // function getTokenInfo(address user)
-  // function getDetailedTokenInfo(address user)
+  function getTokenInfo(address user) public view returns(bool, bool, string memory, string memory,
+    string memory, string memory, uint256, uint, bool) {
+    bool userIsCreator = user == tokenCreator;
+    bool userIsAdmin = userIsCreator; // TODO
+    return (userIsCreator, userIsAdmin, name(), symbol(), description, unit, totalSupply(), tokenCreationTime, fixedQuantity != 0);
+  }
+
+  function getDetailedTokenInfo() public view returns(address[] memory, uint, uint256, uint256, uint,
+    bool[] memory, uint[] memory, string memory) {
+
+    bool[] memory props = new bool[](4);
+    props[0] = isTransferable;
+    props[1] = isMintable;
+    props[2] = isBurnable;
+    props[3] = true; // isCapped
+
+    uint[] memory values = new uint[](5);
+    values[0] = cap();
+    values[1] = uint(decimals());
+    values[2] = fixedQuantity;
+    values[3] = userDefinedQuantityFactor;
+    values[4] = initialSupply;
+
+    return (requiredProofTypes, nextClaimId, balanceOf(msg.sender), totalSupply(), tokenCreationTime, props, values, actionsText);
+  }
 }

--- a/contracts/Fin4Token.sol
+++ b/contracts/Fin4Token.sol
@@ -5,10 +5,13 @@ import 'contracts/Fin4TokenBase.sol';
 
 contract Fin4Token is Fin4TokenBase, ERC20Plus {
 
-  constructor(string memory name, string memory symbol, address tokenCreator, bool[] memory properties, uint[] memory values)
-    ERC20Plus(name, symbol, uint8(values[1]), tokenCreator, properties[2], properties[0], properties[1], values[2])
+  constructor(string memory name, string memory symbol, address _tokenCreator, bool isBurnable,
+    bool isTransferable, bool isMintable, uint8 decimals, uint _initialSupply)
+    ERC20Plus(name, symbol, decimals, _tokenCreator, isBurnable, isTransferable, isMintable, _initialSupply)
     Fin4TokenBase()
     public {
+      tokenCreator = _tokenCreator;
+      initialSupply = _initialSupply;
       // Otherwise token creators can mint themselves rich via command line #ConceptualDecision
       _removeMinter(tokenCreator);
     }

--- a/contracts/Fin4TokenBase.sol
+++ b/contracts/Fin4TokenBase.sol
@@ -22,17 +22,15 @@ contract Fin4TokenBase { // abstract class
     tokenCreationTime = now;
   }
 
-  function init(address Fin4ClaimingAddr, address Fin4ProvingAddr, string memory _description, string memory _actionsText,
-    address _tokenCreator, uint _fixedQuantity, uint _userDefinedQuantityFactor, uint _initialSupply) public {
+  function init(address Fin4ClaimingAddr, address Fin4ProvingAddr, string memory _description,
+    string memory _actionsText, uint _fixedQuantity, uint _userDefinedQuantityFactor) public {
     require(!initDone, "init() can only be called once"); // TODO also require token creator?
     Fin4ClaimingAddress = Fin4ClaimingAddr;
     Fin4ProvingAddress = Fin4ProvingAddr;
     description = _description;
     actionsText = _actionsText;
-    tokenCreator = _tokenCreator;
     fixedQuantity = _fixedQuantity;
     userDefinedQuantityFactor = _userDefinedQuantityFactor;
-    initialSupply = _initialSupply;
     initDone = true;
   }
 

--- a/contracts/Fin4TokenCreator.sol
+++ b/contracts/Fin4TokenCreator.sol
@@ -19,6 +19,14 @@ contract Fin4TokenCreator {
         Fin4ProvingAddress = Fin4ProvingAddr;
     }
 
+    // these two methods are propbably super costly
+
+    function nameCheck(string memory name) public returns(string memory) {
+        uint len = name.length();
+        require(len > 0, "Name can't be empty");
+        return name;
+    }
+
     function symbolCheck(string memory symbol) public returns(string memory) {
         uint len = symbol.length();
         require(len >= 3 && len <= 5, "Symbol must have between 3 and 5 characters");
@@ -56,7 +64,7 @@ contract Fin4UncappedTokenCreator is Fin4TokenCreator {
     function createNewToken(string memory name, string memory symbol, string memory description, string memory actionsText,
         bool[] memory properties, uint[] memory values, address[] memory requiredProofTypes) public returns(address) {
 
-        Fin4TokenBase token = new Fin4Token(name, symbolCheck(symbol), msg.sender,
+        Fin4TokenBase token = new Fin4Token(nameCheck(name), symbolCheck(symbol), msg.sender,
             properties[0], properties[1], properties[2], uint8(values[0]), values[1]);
 
         postCreationSteps(token, description, actionsText, values, requiredProofTypes);
@@ -74,7 +82,7 @@ contract Fin4CappedTokenCreator is Fin4TokenCreator {
     function createNewCappedToken(string memory name, string memory symbol, string memory description, string memory actionsText,
         bool[] memory properties, uint[] memory values, address[] memory requiredProofTypes) public returns(address) {
 
-        Fin4TokenBase token = new Fin4TokenCapped(name, symbolCheck(symbol), msg.sender,
+        Fin4TokenBase token = new Fin4TokenCapped(nameCheck(name), symbolCheck(symbol), msg.sender,
             properties[0], properties[1], properties[2], uint8(values[0]), values[1], values[4]);
 
         postCreationSteps(token, description, actionsText, values, requiredProofTypes);

--- a/contracts/Fin4TokenCreator.sol
+++ b/contracts/Fin4TokenCreator.sol
@@ -5,8 +5,13 @@ import 'contracts/Fin4Token.sol';
 contract Fin4TokenCreator {
 
     address public Fin4ClaimingAddress;
-    constructor(address Fin4ClaimingAddr) public {
+    address public Fin4TokenManagementAddress;
+    address public Fin4ProvingAddress;
+
+    constructor(address Fin4ClaimingAddr, address Fin4TokenManagementAddr, address Fin4ProvingAddr) public {
         Fin4ClaimingAddress = Fin4ClaimingAddr;
+        Fin4TokenManagementAddress = Fin4TokenManagementAddr;
+        Fin4ProvingAddress = Fin4ProvingAddr;
     }
 
     function postCreationSteps(Fin4TokenBase token) public {
@@ -17,8 +22,8 @@ contract Fin4TokenCreator {
 
 contract Fin4UncappedTokenCreator is Fin4TokenCreator {
 
-    constructor(address Fin4ClaimingAddr)
-    Fin4TokenCreator(Fin4ClaimingAddr)
+    constructor(address Fin4ClaimingAddr, address Fin4TokenManagementAddr, address Fin4ProvingAddr)
+    Fin4TokenCreator(Fin4ClaimingAddr, Fin4TokenManagementAddr, Fin4ProvingAddr)
     public {}
 
     function createNewToken(string memory name, string memory _symbol, bool isBurnable, bool isTransferable,
@@ -35,8 +40,8 @@ contract Fin4UncappedTokenCreator is Fin4TokenCreator {
 
 contract Fin4CappedTokenCreator is Fin4TokenCreator {
 
-    constructor(address Fin4ClaimingAddr)
-    Fin4TokenCreator(Fin4ClaimingAddr)
+    constructor(address Fin4ClaimingAddr, address Fin4TokenManagementAddr, address Fin4ProvingAddr)
+    Fin4TokenCreator(Fin4ClaimingAddr, Fin4TokenManagementAddr, Fin4ProvingAddr)
     public {}
 
     function createNewCappedToken(string memory name, string memory _symbol, bool isBurnable, bool isTransferable,

--- a/contracts/Fin4TokenCreator.sol
+++ b/contracts/Fin4TokenCreator.sol
@@ -2,17 +2,30 @@ pragma solidity ^0.5.0;
 
 import 'contracts/Fin4Token.sol';
 import 'contracts/Fin4TokenManagement.sol';
+import "solidity-util/lib/Strings.sol";
 
 contract Fin4TokenCreator {
+    using Strings for string;
 
     address public Fin4ClaimingAddress;
     address public Fin4TokenManagementAddress;
     address public Fin4ProvingAddress;
 
+    mapping (string => bool) public symbolIsUsed;
+
     constructor(address Fin4ClaimingAddr, address Fin4TokenManagementAddr, address Fin4ProvingAddr) public {
         Fin4ClaimingAddress = Fin4ClaimingAddr;
         Fin4TokenManagementAddress = Fin4TokenManagementAddr;
         Fin4ProvingAddress = Fin4ProvingAddr;
+    }
+
+    function symbolCheck(string memory symbol) public returns(string memory) {
+        uint len = symbol.length();
+        require(len >= 3 && len <= 5, "Symbol must have between 3 and 5 characters");
+        string memory sym = symbol.upper();
+        require(!symbolIsUsed[sym], "Symbol is already in use");
+        symbolIsUsed[sym] = true;
+        return sym;
     }
 
     function postCreationSteps(Fin4TokenBase token, string memory description, string memory actionsText,
@@ -43,7 +56,7 @@ contract Fin4UncappedTokenCreator is Fin4TokenCreator {
     function createNewToken(string memory name, string memory symbol, string memory description, string memory actionsText,
         bool[] memory properties, uint[] memory values, address[] memory requiredProofTypes) public returns(address) {
 
-        Fin4TokenBase token = new Fin4Token(name, symbol, msg.sender,
+        Fin4TokenBase token = new Fin4Token(name, symbolCheck(symbol), msg.sender,
             properties[0], properties[1], properties[2], uint8(values[0]), values[1]);
 
         postCreationSteps(token, description, actionsText, values, requiredProofTypes);
@@ -61,7 +74,7 @@ contract Fin4CappedTokenCreator is Fin4TokenCreator {
     function createNewCappedToken(string memory name, string memory symbol, string memory description, string memory actionsText,
         bool[] memory properties, uint[] memory values, address[] memory requiredProofTypes) public returns(address) {
 
-        Fin4TokenBase token = new Fin4TokenCapped(name, symbol, msg.sender,
+        Fin4TokenBase token = new Fin4TokenCapped(name, symbolCheck(symbol), msg.sender,
             properties[0], properties[1], properties[2], uint8(values[0]), values[1], values[4]);
 
         postCreationSteps(token, description, actionsText, values, requiredProofTypes);

--- a/contracts/Fin4TokenCreator.sol
+++ b/contracts/Fin4TokenCreator.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.5.0;
+
+import 'contracts/Fin4Token.sol';
+
+contract Fin4TokenCreator {
+
+    address public Fin4ClaimingAddress;
+    constructor(address Fin4ClaimingAddr) public {
+        Fin4ClaimingAddress = Fin4ClaimingAddr;
+    }
+
+    function createNewToken(string memory name, string memory _symbol, bool isBurnable, bool isTransferable,
+    bool isMintable, uint8 decimals, uint initialSupply) public returns(address) {
+
+        Fin4TokenBase newToken = new Fin4Token(name, _symbol, msg.sender,
+            isBurnable, isTransferable, isMintable, decimals, initialSupply);
+
+        newToken.addMinter(Fin4ClaimingAddress);
+        newToken.renounceMinter(); // Fin4TokenCreator should not have the MinterRole on tokens
+
+        return address(newToken);
+    }
+}

--- a/contracts/Fin4TokenCreator.sol
+++ b/contracts/Fin4TokenCreator.sol
@@ -79,7 +79,7 @@ contract Fin4CappedTokenCreator is Fin4TokenCreator {
     Fin4TokenCreator(Fin4ClaimingAddr, Fin4TokenManagementAddr, Fin4ProvingAddr)
     public {}
 
-    function createNewCappedToken(string memory name, string memory symbol, string memory description, string memory actionsText,
+    function createNewToken(string memory name, string memory symbol, string memory description, string memory actionsText,
         bool[] memory properties, uint[] memory values, address[] memory requiredProofTypes) public returns(address) {
 
         Fin4TokenBase token = new Fin4TokenCapped(nameCheck(name), symbolCheck(symbol), msg.sender,

--- a/contracts/Fin4TokenCreator.sol
+++ b/contracts/Fin4TokenCreator.sol
@@ -9,35 +9,44 @@ contract Fin4TokenCreator {
         Fin4ClaimingAddress = Fin4ClaimingAddr;
     }
 
-    function createNewToken(string memory name, string memory _symbol, bool isBurnable, bool isTransferable,
-    bool isMintable, uint8 decimals, uint initialSupply) public returns(address) {
-
-        Fin4TokenBase newToken = new Fin4Token(name, _symbol, msg.sender,
-            isBurnable, isTransferable, isMintable, decimals, initialSupply);
-
-        newToken.addMinter(Fin4ClaimingAddress);
-        newToken.renounceMinter(); // Fin4TokenCreator should not have the MinterRole on tokens
-
-        return address(newToken);
+    function postCreationSteps(Fin4TokenBase token) public {
+        token.addMinter(Fin4ClaimingAddress);
+        token.renounceMinter(); // Fin4TokenCreator should not have the MinterRole on tokens
     }
 }
 
-contract Fin4CappedTokenCreator {
+contract Fin4UncappedTokenCreator is Fin4TokenCreator {
 
-    address public Fin4ClaimingAddress;
-    constructor(address Fin4ClaimingAddr) public {
-        Fin4ClaimingAddress = Fin4ClaimingAddr;
+    constructor(address Fin4ClaimingAddr)
+    Fin4TokenCreator(Fin4ClaimingAddr)
+    public {}
+
+    function createNewToken(string memory name, string memory _symbol, bool isBurnable, bool isTransferable,
+        bool isMintable, uint8 decimals, uint initialSupply) public returns(address) {
+
+        Fin4TokenBase token = new Fin4Token(name, _symbol, msg.sender,
+            isBurnable, isTransferable, isMintable, decimals, initialSupply);
+
+        postCreationSteps(token);
+
+        return address(token);
     }
+}
+
+contract Fin4CappedTokenCreator is Fin4TokenCreator {
+
+    constructor(address Fin4ClaimingAddr)
+    Fin4TokenCreator(Fin4ClaimingAddr)
+    public {}
 
     function createNewCappedToken(string memory name, string memory _symbol, bool isBurnable, bool isTransferable,
-    bool isMintable, uint8 decimals, uint initialSupply, uint cap) public returns(address) {
+        bool isMintable, uint8 decimals, uint initialSupply, uint cap) public returns(address) {
 
-        Fin4TokenBase newToken = new Fin4TokenCapped(name, _symbol, msg.sender,
+        Fin4TokenBase token = new Fin4TokenCapped(name, _symbol, msg.sender,
             isBurnable, isTransferable, isMintable, decimals, initialSupply, cap);
 
-        newToken.addMinter(Fin4ClaimingAddress);
-        newToken.renounceMinter(); // Fin4CappedTokenCreator should not have the MinterRole on tokens
+        postCreationSteps(token);
 
-        return address(newToken);
+        return address(token);
     }
 }

--- a/contracts/Fin4TokenCreator.sol
+++ b/contracts/Fin4TokenCreator.sol
@@ -5,6 +5,11 @@ import 'contracts/Fin4TokenManagement.sol';
 import "solidity-util/lib/Strings.sol";
 
 contract Fin4TokenCreator {
+
+    // This event is only to be able to get the address of the new token into the frontend as return value of send()
+    // The "real" new-token event is emitted from Fin4TokenManagement.registerNewToken()
+    event NewFin4TokenAddress(address tokenAddress);
+
     using Strings for string;
 
     address public Fin4ClaimingAddress;
@@ -52,6 +57,7 @@ contract Fin4TokenCreator {
         }
 
         Fin4TokenManagement(Fin4TokenManagementAddress).registerNewToken(address(token));
+        emit NewFin4TokenAddress(address(token));
     }
 }
 

--- a/contracts/Fin4TokenCreator.sol
+++ b/contracts/Fin4TokenCreator.sol
@@ -21,3 +21,23 @@ contract Fin4TokenCreator {
         return address(newToken);
     }
 }
+
+contract Fin4CappedTokenCreator {
+
+    address public Fin4ClaimingAddress;
+    constructor(address Fin4ClaimingAddr) public {
+        Fin4ClaimingAddress = Fin4ClaimingAddr;
+    }
+
+    function createNewCappedToken(string memory name, string memory _symbol, bool isBurnable, bool isTransferable,
+    bool isMintable, uint8 decimals, uint initialSupply, uint cap) public returns(address) {
+
+        Fin4TokenBase newToken = new Fin4TokenCapped(name, _symbol, msg.sender,
+            isBurnable, isTransferable, isMintable, decimals, initialSupply, cap);
+
+        newToken.addMinter(Fin4ClaimingAddress);
+        newToken.renounceMinter(); // Fin4CappedTokenCreator should not have the MinterRole on tokens
+
+        return address(newToken);
+    }
+}

--- a/contracts/Fin4TokenManagement.sol
+++ b/contracts/Fin4TokenManagement.sol
@@ -14,15 +14,11 @@ contract Fin4TokenManagement {
         uint creationTime, bool hasFixedMintingQuantity);
 
     address public creator;
-    address public Fin4ClaimingAddress;
-    address public Fin4ProvingAddress;
     address public Fin4SystemParametersAddress;
     address public Fin4ReputationAddress;
 
-    constructor(address Fin4ClaimingAddr, address Fin4ProvingAddr, address Fin4SystemParametersAddr) public {
+    constructor(address Fin4SystemParametersAddr) public {
         creator = msg.sender;
-        Fin4ClaimingAddress = Fin4ClaimingAddr;
-        Fin4ProvingAddress = Fin4ProvingAddr;
         Fin4SystemParametersAddress = Fin4SystemParametersAddr;
     }
 

--- a/contracts/Fin4TokenManagement.sol
+++ b/contracts/Fin4TokenManagement.sol
@@ -30,38 +30,17 @@ contract Fin4TokenManagement {
 
     address[] public allFin4Tokens;
 
-    function initNewToken(address tokenAddress, string memory description, string memory actionsText,
-        uint fixedQuantity, uint userDefinedQuantityFactor, address[] memory requiredProofTypes) public {
-        /*
-            This check seems super costly as it brings this contract to out of gas errors during deployment quickly
-            Commenting it out until a better (cheaper) solution is found
-        // mapping (string => bool) public symbolIsUsed;
-        uint symLen = symbol.length();
-        require(symLen >= 3 && symLen <= 5, "Symbol must have between 3 and 5 characters");
-        string memory _symbol = symbol.upper();
-        require(!symbolIsUsed[_symbol], "Symbol is already in use");
-        symbolIsUsed[_symbol] = true;
-        */
-
-        require(
-            (fixedQuantity == 0 && userDefinedQuantityFactor != 0) ||
-            (fixedQuantity != 0 && userDefinedQuantityFactor == 0),
-            "Exactly one of fixedQuantity and userDefinedQuantityFactor must be nonzero");
-
+    function registerNewToken(address tokenAddress) public {
         Fin4TokenBase token = Fin4TokenBase(tokenAddress);
 
-        token.init(Fin4ClaimingAddress, Fin4ProvingAddress, description, actionsText, fixedQuantity, userDefinedQuantityFactor);
-
-        for (uint i = 0; i < requiredProofTypes.length; i++) {
-            token.addRequiredProofType(requiredProofTypes[i]);
-        }
-
         // REP reward for creating a new token
-        MintingStub(Fin4ReputationAddress).mint(msg.sender, Fin4SystemParameters(Fin4SystemParametersAddress).REPforTokenCreation());
+        MintingStub(Fin4ReputationAddress).mint(token.tokenCreator(), Fin4SystemParameters(Fin4SystemParametersAddress).REPforTokenCreation());
 
         allFin4Tokens.push(tokenAddress);
-        emit Fin4TokenCreated(tokenAddress, token.name(), token.symbol(), description, "",
-            msg.sender, token.tokenCreationTime(), fixedQuantity != 0);
+
+        // or cheaper/better to get these values via one getter?
+        emit Fin4TokenCreated(tokenAddress, token.name(), token.symbol(), token.description(), "",
+            token.tokenCreator(), token.tokenCreationTime(), token.fixedQuantity() != 0);
     }
 
     function getAllFin4Tokens() public view returns(address[] memory) {

--- a/contracts/Fin4TokenManagement.sol
+++ b/contracts/Fin4TokenManagement.sol
@@ -4,10 +4,8 @@ pragma solidity ^0.5.0;
 import 'contracts/Fin4Token.sol';
 import 'contracts/stub/MintingStub.sol';
 import 'contracts/Fin4SystemParameters.sol';
-import "solidity-util/lib/Strings.sol";
 
 contract Fin4TokenManagement {
-    using Strings for string;
 
     // TODO do we need the indexed keyword for event params?
     event Fin4TokenCreated(address addr, string name, string symbol, string description, string unit, address creator,

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,7 +3,7 @@ const path = require('path');
 const config = require('../config.json');
 
 const Fin4Main = artifacts.require('Fin4Main');
-const Fin4TokenCreator = artifacts.require('Fin4TokenCreator');
+const Fin4UncappedTokenCreator = artifacts.require('Fin4UncappedTokenCreator');
 const Fin4CappedTokenCreator = artifacts.require('Fin4CappedTokenCreator');
 const Fin4TokenManagement = artifacts.require('Fin4TokenManagement');
 const Fin4Claiming = artifacts.require('Fin4Claiming');
@@ -47,9 +47,9 @@ module.exports = async function(deployer) {
 	await deployer.deploy(Fin4Claiming, Fin4SystemParametersInstance.address);
 	const Fin4ClaimingInstance = await Fin4Claiming.deployed();
 
-	await deployer.deploy(Fin4TokenCreator, Fin4ClaimingInstance.address);
+	await deployer.deploy(Fin4UncappedTokenCreator, Fin4ClaimingInstance.address);
 	await deployer.deploy(Fin4CappedTokenCreator, Fin4ClaimingInstance.address);
-	const Fin4TokenCreatorInstance = await Fin4TokenCreator.deployed();
+	const Fin4UncappedTokenCreatorInstance = await Fin4UncappedTokenCreator.deployed();
 	const Fin4CappedTokenCreatorInstance = await Fin4CappedTokenCreator.deployed();
 
 	await deployer.deploy(
@@ -70,7 +70,7 @@ module.exports = async function(deployer) {
 	const Fin4OracleHubInstance = await Fin4OracleHub.deployed();
 
 	await Fin4MainInstance.setSatelliteAddresses(
-		Fin4TokenCreatorInstance.address,
+		Fin4UncappedTokenCreatorInstance.address,
 		Fin4CappedTokenCreatorInstance.address,
 		Fin4TokenManagementInstance.address,
 		Fin4ClaimingInstance.address,

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -47,18 +47,14 @@ module.exports = async function(deployer) {
 	await deployer.deploy(Fin4Claiming, Fin4SystemParametersInstance.address);
 	const Fin4ClaimingInstance = await Fin4Claiming.deployed();
 
-	await deployer.deploy(Fin4UncappedTokenCreator, Fin4ClaimingInstance.address);
-	await deployer.deploy(Fin4CappedTokenCreator, Fin4ClaimingInstance.address);
+	await deployer.deploy(Fin4TokenManagement, Fin4SystemParametersInstance.address);
+	const Fin4TokenManagementInstance = await Fin4TokenManagement.deployed();
+
+	await deployer.deploy(Fin4UncappedTokenCreator, Fin4ClaimingInstance.address, Fin4TokenManagementInstance.address, Fin4ProvingInstance.address);
+	await deployer.deploy(Fin4CappedTokenCreator, Fin4ClaimingInstance.address, Fin4TokenManagementInstance.address, Fin4ProvingInstance.address);
 	const Fin4UncappedTokenCreatorInstance = await Fin4UncappedTokenCreator.deployed();
 	const Fin4CappedTokenCreatorInstance = await Fin4CappedTokenCreator.deployed();
 
-	await deployer.deploy(
-		Fin4TokenManagement,
-		Fin4ClaimingInstance.address,
-		Fin4ProvingInstance.address,
-		Fin4SystemParametersInstance.address
-	);
-	const Fin4TokenManagementInstance = await Fin4TokenManagement.deployed();
 	await deployer.deploy(Fin4Collections);
 	const Fin4CollectionsInstance = await Fin4Collections.deployed();
 	await deployer.deploy(Fin4Messaging);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,6 +3,7 @@ const path = require('path');
 const config = require('../config.json');
 
 const Fin4Main = artifacts.require('Fin4Main');
+const Fin4TokenCreator = artifacts.require('Fin4TokenCreator');
 const Fin4TokenManagement = artifacts.require('Fin4TokenManagement');
 const Fin4Claiming = artifacts.require('Fin4Claiming');
 const Fin4Collections = artifacts.require('Fin4Collections');
@@ -44,6 +45,9 @@ module.exports = async function(deployer) {
 	const Fin4ProvingInstance = await Fin4Proving.deployed();
 	await deployer.deploy(Fin4Claiming, Fin4SystemParametersInstance.address);
 	const Fin4ClaimingInstance = await Fin4Claiming.deployed();
+
+	await deployer.deploy(Fin4TokenCreator, Fin4ClaimingInstance.address);
+
 	await deployer.deploy(
 		Fin4TokenManagement,
 		Fin4ClaimingInstance.address,

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -49,6 +49,8 @@ module.exports = async function(deployer) {
 
 	await deployer.deploy(Fin4TokenCreator, Fin4ClaimingInstance.address);
 	await deployer.deploy(Fin4CappedTokenCreator, Fin4ClaimingInstance.address);
+	const Fin4TokenCreatorInstance = await Fin4TokenCreator.deployed();
+	const Fin4CappedTokenCreatorInstance = await Fin4CappedTokenCreator.deployed();
 
 	await deployer.deploy(
 		Fin4TokenManagement,
@@ -68,6 +70,8 @@ module.exports = async function(deployer) {
 	const Fin4OracleHubInstance = await Fin4OracleHub.deployed();
 
 	await Fin4MainInstance.setSatelliteAddresses(
+		Fin4TokenCreatorInstance.address,
+		Fin4CappedTokenCreatorInstance.address,
 		Fin4TokenManagementInstance.address,
 		Fin4ClaimingInstance.address,
 		Fin4CollectionsInstance.address,

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -4,6 +4,7 @@ const config = require('../config.json');
 
 const Fin4Main = artifacts.require('Fin4Main');
 const Fin4TokenCreator = artifacts.require('Fin4TokenCreator');
+const Fin4CappedTokenCreator = artifacts.require('Fin4CappedTokenCreator');
 const Fin4TokenManagement = artifacts.require('Fin4TokenManagement');
 const Fin4Claiming = artifacts.require('Fin4Claiming');
 const Fin4Collections = artifacts.require('Fin4Collections');
@@ -47,6 +48,7 @@ module.exports = async function(deployer) {
 	const Fin4ClaimingInstance = await Fin4Claiming.deployed();
 
 	await deployer.deploy(Fin4TokenCreator, Fin4ClaimingInstance.address);
+	await deployer.deploy(Fin4CappedTokenCreator, Fin4ClaimingInstance.address);
 
 	await deployer.deploy(
 		Fin4TokenManagement,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"dependencies": {
 		"@truffle/hdwallet-provider": "1.0.18",
-		"openzeppelin-solidity": "2.3.0",
+		"openzeppelin-solidity": "^2.4.0",
 		"solidity-util": "github:willitscale/solidity-util"
 	}
 }


### PR DESCRIPTION
By introducing a `Fin4TokenCreator` contract (plus two deriving contracts for *capped* and *uncapped*)  the computational load on `Fin4TokenManagement` was mitigated enough to avoid the notorious `out-of-gas` error upon deployment.

Since the `openzeppelin-contracts` package was updated to [v2.4.0](https://github.com/OpenZeppelin/openzeppelin-contracts/releases/tag/v2.4.0) something got more expensive and `out-of-gas` happened without any change.

Plus, I postponed the creation of capped tokens because it also caused `out-of-gas`. With this refactoring  (which brings three new contracts 👎 not sure that could have been avoided though) it is possible to both use `openzeppelin-contracts` v2.4.0, as well as create capped tokens 🎉 

Corresponds with [PR #19](https://github.com/FuturICT2/FIN4Xplorer/pull/19) in FIN4Xplorer.